### PR TITLE
fix checking Zenstruck version

### DIFF
--- a/src/Doctrine/Filter/TextSearchFilter.php
+++ b/src/Doctrine/Filter/TextSearchFilter.php
@@ -112,7 +112,7 @@ final class TextSearchFilter extends AbstractFilter
                 'property' => $this->parameterName,
                 'type' => Type::BUILTIN_TYPE_STRING,
                 'required' => false,
-                'description' => 'Search in string properties: '.implode(', ', array_map(fn($property) => '"'.$property.'"', array_keys($this->properties))),
+                'description' => 'Search in string properties: '.implode(', ', array_map(static fn(string $property): string => '"'.$property.'"', array_keys($this->properties))),
             ],
         ];
     }

--- a/src/Test/FactoriesProxyHelper.php
+++ b/src/Test/FactoriesProxyHelper.php
@@ -8,12 +8,12 @@ trait FactoriesProxyHelper
     private function getRealEntityObject(object $entity): object
     {
         // If Zenstruck Foundry v1.x is used
-        if (interface_exists('Zenstruck\Foundry\Proxy') && $entity instanceof \Zenstruck\Foundry\Proxy) {
+        if ($entity instanceof \Zenstruck\Foundry\Proxy) {
             return $entity->object();
         }
 
         // For Zenstruck Foundry v2.x
-        if (interface_exists('Zenstruck\Foundry\Persistence\Proxy') && $entity instanceof \Zenstruck\Foundry\Persistence\Proxy) {
+        if ($entity instanceof \Zenstruck\Foundry\Persistence\Proxy) {
             return $entity->_real();
         }
 
@@ -23,12 +23,12 @@ trait FactoriesProxyHelper
     private function isEntityProxy(object $entity): bool
     {
         // If Zenstruck Foundry v1.x is used
-        if (interface_exists('Zenstruck\Foundry\Proxy') && $entity instanceof \Zenstruck\Foundry\Proxy) {
+        if ($entity instanceof \Zenstruck\Foundry\Proxy) {
             return true;
         }
 
         // For Zenstruck Foundry v2.x
-        if (interface_exists('Zenstruck\Foundry\Persistence\Proxy') && $entity instanceof \Zenstruck\Foundry\Persistence\Proxy) {
+        if ($entity instanceof \Zenstruck\Foundry\Persistence\Proxy) {
             return true;
         }
 


### PR DESCRIPTION
- **start working on support of foundry v2**
- **require php 8.2. Add mode config if app is using uuid as identifier or classic id**
- **refacor uuid filter. join association instead of adding 'uuid' as property**
- **fix typo**
- **add support of different search strategies TextSearchFilter**
- **add support of foundry 2.0. upgrade phpunit**
- **phpcs fix**
- **fix closure static func**
- **improve description for TextsearchFilter**
- **don't check if interface exists**
