### PR TITLE
id search

### DIFF
--- a/src/Doctrine/Extension/IdentifierCollectionFilterExtension.php
+++ b/src/Doctrine/Extension/IdentifierCollectionFilterExtension.php
@@ -46,6 +46,10 @@ final readonly class IdentifierCollectionFilterExtension implements QueryCollect
      */
     protected function getIdFromIri(string $iri): int|string|null
     {
+        if (is_numeric($iri) && $this->identifierMode === IdentifierMode::ID) {
+            return (int) $iri;
+        }
+
         try {
             $item = $this->iriConverter->getResourceFromIri($iri, ['fetch_data' => false]);
 
@@ -54,8 +58,7 @@ final readonly class IdentifierCollectionFilterExtension implements QueryCollect
                 IdentifierMode::UUID => $item->getUuid()->toBinary(),
             };
         } catch (InvalidArgumentException|ItemNotFoundException) {
+            return null;
         }
-
-        return null;
     }
 }

--- a/src/Test/ApiTestCase.php
+++ b/src/Test/ApiTestCase.php
@@ -81,9 +81,13 @@ abstract class ApiTestCase extends \ApiPlatform\Symfony\Bundle\Test\ApiTestCase
 
     protected function serializeEntity(object $entity, array $properties): array
     {
-        $serialized = [
-            '@id' => $this->getItemIri($entity),
-        ];
+        $id = $this->getItemIri($entity);
+        $serialized = [];
+
+        if (! str_contains($id, '/.well-known/genid/')) {
+            $serialized['@id'] = $id;
+        }
+
         $serialized += $this->serializeCommonFields($entity);
 
         $entity = $this->getRealEntityObject($entity);
@@ -121,7 +125,7 @@ abstract class ApiTestCase extends \ApiPlatform\Symfony\Bundle\Test\ApiTestCase
         $entity = $this->getRealEntityObject($entity);
 
         if (method_exists($entity, 'getUuid')) {
-            $serialized['uuid'] = (string)$entity->getUuid();
+            $serialized['uuid'] = (string) $entity->getUuid();
         }
 
         if (method_exists($entity, 'getPosition')) {
@@ -144,7 +148,7 @@ abstract class ApiTestCase extends \ApiPlatform\Symfony\Bundle\Test\ApiTestCase
             $value instanceof \DateTimeInterface => $this->serializeDateTimeAsString($value),
             $value instanceof Collection => array_map(fn(object $item) => $this->getItemIri($item), $value->toArray()),
             is_object($value) && ($this->isEntityProxy($value) || str_contains(ClassUtils::getClass($value), 'App\\Entity\\')) => $this->getItemIri($value),
-            $value instanceof \Stringable => (string)$value,
+            $value instanceof \Stringable => (string) $value,
             $value instanceof \BackedEnum => $value->value,
             is_float($value) => $this->preciseZeroFraction($value),
             is_array($value) => array_map($this->serializeValue(...), $value),
@@ -154,8 +158,8 @@ abstract class ApiTestCase extends \ApiPlatform\Symfony\Bundle\Test\ApiTestCase
 
     protected function preciseZeroFraction(float $value): int|float
     {
-        if ($value === (float)(int)$value) {
-            return (int)$value;
+        if ($value === (float) (int) $value) {
+            return (int) $value;
         }
 
         return $value;

--- a/tests/Doctrine/Extension/IdentifierCollectionFilterExtensionTest.php
+++ b/tests/Doctrine/Extension/IdentifierCollectionFilterExtensionTest.php
@@ -36,6 +36,29 @@ class IdentifierCollectionFilterExtensionTest extends AbstractDoctrineExtension
         self::assertSame($dummy->getId(), $result[0]->getId());
     }
 
+    public function testFilterWithNumbericIriId(): void
+    {
+        DummyFactory::createMany(3);
+
+        $dummy = DummyFactory::createOne();
+        $id = (string) $dummy->getId();
+
+        DummyFactory::assert()->count(4);
+
+        $mockIriConverter = $this->createMock(IriConverterInterface::class);
+        $mockIriConverter->expects($this->once())->method('getResourceFromIri')->with($id)->willReturn($dummy);
+
+        $filterExtension = new IdentifierCollectionFilterExtension($mockIriConverter, IdentifierMode::ID);
+
+        $queryBuilder = $this->repository->createQueryBuilder('o');
+        $filterExtension->applyToCollection($queryBuilder, new QueryNameGenerator(), $this->entityClassName, context: ['filters' => ['id' => $id]]);
+
+        $result = $queryBuilder->getQuery()->getResult();
+
+        self::assertCount(1, $result);
+        self::assertSame($dummy->getId(), $result[0]->getId());
+    }
+
     public function testFilterWithIriIds(): void
     {
         DummyFactory::createMany(3);

--- a/tests/Doctrine/Extension/IdentifierCollectionFilterExtensionTest.php
+++ b/tests/Doctrine/Extension/IdentifierCollectionFilterExtensionTest.php
@@ -46,7 +46,7 @@ class IdentifierCollectionFilterExtensionTest extends AbstractDoctrineExtension
         DummyFactory::assert()->count(4);
 
         $mockIriConverter = $this->createMock(IriConverterInterface::class);
-        $mockIriConverter->expects($this->once())->method('getResourceFromIri')->with($id)->willReturn($dummy);
+        $mockIriConverter->expects($this->never())->method('getResourceFromIri');
 
         $filterExtension = new IdentifierCollectionFilterExtension($mockIriConverter, IdentifierMode::ID);
 


### PR DESCRIPTION
- **require php 8.2. Add mode config if app is using uuid as identifier or classic id**
- **refacor uuid filter. join association instead of adding 'uuid' as property**
- **fix typo**
- **add support of different search strategies TextSearchFilter**
- **require any doctrine package**
- **fix invalid json**
- **start working on support of foundry v2**
- **require php 8.2. Add mode config if app is using uuid as identifier or classic id**
- **refacor uuid filter. join association instead of adding 'uuid' as property**
- **fix typo**
- **add support of different search strategies TextSearchFilter**
- **add support of foundry 2.0. upgrade phpunit**
- **phpcs fix**
- **fix closure static func**
- **improve description for TextsearchFilter**
- **don't check if interface exists**
- **phpcs fix**
- **exclude auto-generate id when serialize entity**
- **add support of scalar ids filter**
